### PR TITLE
Make pkg-build ignore example.rkt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+compiled/

--- a/info.rkt
+++ b/info.rkt
@@ -4,3 +4,4 @@
 (define build-deps '("scribble-lib" "at-exp-lib" "pict-doc"
                      "slideshow-doc" "racket-doc" "scribble-doc"))
 (define scribblings '(("slideshow-text-style.scrbl" () ("Slideshow Libraries"))))
+(define test-omit-paths (if (getenv "PLT_PKG_BUILD_SERVICE") '("example.rkt") '()))


### PR DESCRIPTION
pkg-build attempts to test example.rkt, but this will always [timeout](https://pkg-build.racket-lang.org/server/built/test-fail/slideshow-text-style.txt)
because slideshow is waiting for an input from users. One possible
solution is to add the file to test-omit-paths when pkg-build is
detected.